### PR TITLE
Add SSL toggle and network skip to Proxmox CLI

### DIFF
--- a/backbone/provision.py
+++ b/backbone/provision.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from argparse import ArgumentParser
 from getpass import getpass
 from pathlib import Path
 
@@ -9,29 +10,40 @@ from backbone.proxmox import ProxmoxManager
 
 
 def main(args: list[str] | None = None) -> None:
-    """Interactively create a Proxmox cluster."""
-    host = input("Proxmox Host: ")
-    token_id = input("API Token ID: ")
-    token_secret = getpass("API Token Secret: ")
-    node = input("Node: ")
-    bridge = input("Bridge: ")
-    cidr = input("CIDR: ")
-    count = int(input("Number of VMs: "))
-    private_key = input("SSH Private Key [~/.ssh/id_rsa]: ") or "~/.ssh/id_rsa"
-    public_key = input("SSH Public Key [~/.ssh/id_rsa.pub]: ") or "~/.ssh/id_rsa.pub"
-    machines = []
-    for i in range(count):
-        vmid = int(input(f"VM {i + 1} ID: "))
-        name = input(f"VM {i + 1} name: ")
-        ip = input(f"VM {i + 1} IP: ")
-        cores = int(input(f"VM {i + 1} cores [1]: ") or 1)
-        memory = int(input(f"VM {i + 1} memory MB [1024]: ") or 1024)
-        machines.append({"vmid": vmid, "name": name, "cores": cores, "memory": memory, "ip": ip})
-    mgr = ProxmoxManager(host, token_id, token_secret)
-    mgr.create_cluster(node=node, bridge=bridge, cidr=cidr, machines=machines)
-    playbook = str(Path(__file__).parent.joinpath("playbooks", "setup_ubuntu.yml"))
-    provisioner = AnsibleProvisioner(playbook, private_key)
-    provisioner.provision([m["ip"] for m in machines], public_key)
+	"""Interactively create a Proxmox cluster."""
+	parser = ArgumentParser()
+	parser.add_argument("--insecure", action="store_true", help="Disable SSL certificate verification")
+	parser.add_argument("--skip-private-network", action="store_true", help="Skip creating private network")
+	opts = parser.parse_args(args)
+
+	host = input("Proxmox Host: ")
+	token_id = input("API Token ID: ")
+	token_secret = getpass("API Token Secret: ")
+	node = input("Node: ")
+	bridge = input("Bridge: ")
+	cidr = input("CIDR: ")
+	count = int(input("Number of VMs: "))
+	private_key = input("SSH Private Key [~/.ssh/id_rsa]: ") or "~/.ssh/id_rsa"
+	public_key = input("SSH Public Key [~/.ssh/id_rsa.pub]: ") or "~/.ssh/id_rsa.pub"
+	machines = []
+	for i in range(count):
+		vmid = int(input(f"VM {i + 1} ID: "))
+		name = input(f"VM {i + 1} name: ")
+		ip = input(f"VM {i + 1} IP: ")
+		cores = int(input(f"VM {i + 1} cores [1]: ") or 1)
+		memory = int(input(f"VM {i + 1} memory MB [1024]: ") or 1024)
+		machines.append({"vmid": vmid, "name": name, "cores": cores, "memory": memory, "ip": ip})
+	mgr = ProxmoxManager(host, token_id, token_secret, verify_ssl=not opts.insecure)
+	mgr.create_cluster(
+		node=node,
+		bridge=bridge,
+		cidr=cidr,
+		machines=machines,
+		create_private_network=not opts.skip_private_network,
+	)
+	playbook = str(Path(__file__).parent.joinpath("playbooks", "setup_ubuntu.yml"))
+	provisioner = AnsibleProvisioner(playbook, private_key)
+	provisioner.provision([m["ip"] for m in machines], public_key)
 
 
 if __name__ == "__main__":

--- a/backbone/proxmox.py
+++ b/backbone/proxmox.py
@@ -23,7 +23,16 @@ class ProxmoxManager:
 		if resp.status_code >= 400:
 			raise Exception(f"Failed to create bridge: {resp.text}")
 
-	def create_vm(self, node: str, vmid: int, name: str, bridge: str, cores: int = 1, memory: int = 1024, storage: str = "local-lvm") -> None:
+	def create_vm(
+		self,
+		node: str,
+		vmid: int,
+		name: str,
+		bridge: str,
+		cores: int = 1,
+		memory: int = 1024,
+		storage: str = "local-lvm",
+	) -> None:
 		payload = {
 			"vmid": vmid,
 			"name": name,
@@ -39,7 +48,15 @@ class ProxmoxManager:
 		if resp.status_code >= 400:
 			raise Exception(f"Failed to create VM {name}: {resp.text}")
 
-	def create_cluster(self, node: str, bridge: str, cidr: str, machines: list[dict[str, any]]) -> None:
-		self.create_private_bridge(node, bridge, cidr)
+	def create_cluster(
+		self,
+		node: str,
+		bridge: str,
+		cidr: str,
+		machines: list[dict[str, any]],
+		create_private_network: bool = True,
+	) -> None:
+		if create_private_network:
+			self.create_private_bridge(node, bridge, cidr)
 		for machine in machines:
 			self.create_vm(node=node, bridge=bridge, **machine)

--- a/backbone/tests/test_proxmox.py
+++ b/backbone/tests/test_proxmox.py
@@ -27,6 +27,14 @@ class TestProxmoxManager(unittest.TestCase):
 		with self.assertRaisesRegex(Exception, "Failed to create VM"):
 			mgr.create_vm("node1", 101, "test", "vmbr0")
 
+	@patch.object(ProxmoxManager, "create_private_bridge")
+	@patch.object(ProxmoxManager, "create_vm")
+	def test_create_cluster_skip_private_network(self, create_vm, create_bridge):
+		mgr = ProxmoxManager("host", "id", "secret")
+		mgr.create_cluster("node1", "vmbr0", "10.0.0.0/24", [], create_private_network=False)
+		create_bridge.assert_not_called()
+
+
 class TestAnsibleProvisioner(unittest.TestCase):
 	@patch("backbone.ansible.subprocess.run")
 	def test_provision_fail(self, run):


### PR DESCRIPTION
## Summary
- add ability to disable SSL verification when provisioning Proxmox
- allow skipping private network creation
- expose these options in `backbone provision` and interactive script
- test cluster creation when the bridge is skipped

## Testing
- `ruff check --fix backbone/proxmox.py backbone/cli.py backbone/provision.py backbone/tests/test_proxmox.py`
- `ruff format backbone/proxmox.py backbone/cli.py backbone/provision.py backbone/tests/test_proxmox.py`
- `python -m backbone.tests` *(fails: ModuleNotFoundError: No module named 'coverage')*

------
https://chatgpt.com/codex/tasks/task_b_684ecd0782fc8330a735be3cecc3c1ca