### PR TITLE
Add remote_tmp config to Ansible runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Additionally, customers lacked full control over their servers—no SSH access, 
 
 To self host or to setup Press locally follow the steps in the [Local Development Environment Setup Guide](https://docs.frappe.io/cloud/local-fc-setup) or [this YouTube video](https://www.youtube.com/watch?v=Xb9QHnUrIEk)
 
+Press uses `/tmp/ansible` on remote hosts for Ansible's temporary files.
+Ensure this directory exists and is writable by all remote users.
+
 ## Learn and connect
 
 - [Telegram Public Group](https://t.me/frappecloud)

--- a/press/press/doctype/ansible_console/ansible_console.py
+++ b/press/press/doctype/ansible_console/ansible_console.py
@@ -131,6 +131,7 @@ class AnsibleAdHoc:
 			check=False,
 			connection="ssh",
 			extra_vars=[],
+			remote_tmp="/tmp/ansible",
 			remote_user="root",
 			start_at_task=None,
 			syntax=False,

--- a/press/runner.py
+++ b/press/runner.py
@@ -166,6 +166,7 @@ class Ansible:
 			connection="ssh",
 			# This is the only way to pass variables that preserves newlines
 			extra_vars=[f"{cstr(key)}='{cstr(value)}'" for key, value in self.variables.items()],
+			remote_tmp="/tmp/ansible",
 			remote_user=user,
 			start_at_task=None,
 			syntax=False,


### PR DESCRIPTION
## Summary
- set `/tmp/ansible` as `remote_tmp` for Ansible and AnsibleAdHoc
- document requirement of this directory in README

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_687149caeacc8330a776e84f93ee7bbb