### PR TITLE
Refine uptime color thresholds

### DIFF
--- a/dashboard/src/views/site/SiteAnalyticsUptime.vue
+++ b/dashboard/src/views/site/SiteAnalyticsUptime.vue
@@ -16,10 +16,14 @@
 						d[type.key] === undefined
 							? 'bg-white'
 							: d[type.key] === 1
-							? 'bg-green-500'
-							: d[type.key] === 0
-							? 'bg-red-500'
-							: 'bg-yellow-500'
+								? 'bg-emerald-500'
+								: d[type.key] >= 0.95
+									? 'bg-green-500'
+									: d[type.key] === 0 || d[type.key] < 0.3
+										? 'bg-red-500'
+										: d[type.key] >= 0.3 && d[type.key] <= 0.6
+											? 'bg-orange-500'
+											: 'bg-yellow-500',
 					]"
 					:title="
 						d[type.key]
@@ -55,12 +59,12 @@ export default {
 			const average = ((total / i) * 100).toFixed(2);
 
 			return !isNaN(average) ? `Average: ${average}%` : '';
-		}
+		},
 	},
 	methods: {
 		formatDate(date) {
 			return DateTime.fromSQL(date).toLocaleString(DateTime.DATETIME_FULL);
-		}
-	}
+		},
+	},
 };
 </script>

--- a/dashboard/src2/components/site/SiteUptime.vue
+++ b/dashboard/src2/components/site/SiteUptime.vue
@@ -15,10 +15,14 @@
 					d[type.key] === undefined
 						? 'bg-white'
 						: d[type.key] === 1
-						? 'bg-green-500'
-						: d[type.key] === 0
-						? 'bg-red-500'
-						: 'bg-yellow-500'
+							? 'bg-emerald-500'
+							: d[type.key] >= 0.95
+								? 'bg-green-500'
+								: d[type.key] === 0 || d[type.key] < 0.3
+									? 'bg-red-500'
+									: d[type.key] >= 0.3 && d[type.key] <= 0.6
+										? 'bg-orange-500'
+										: 'bg-yellow-500',
 				]"
 				:title="
 					d[type.key]
@@ -54,12 +58,12 @@ export default {
 			const average = ((total / i) * 100).toFixed(2);
 
 			return !isNaN(average) ? `Average: ${average}%` : '';
-		}
+		},
 	},
 	methods: {
 		formatDate(date) {
 			return DateTime.fromSQL(date).toLocaleString(DateTime.DATETIME_FULL);
-		}
-	}
+		},
+	},
 };
 </script>


### PR DESCRIPTION
## Summary
- tweak color thresholds for uptime display across Site views

## Testing
- `npx prettier -w dashboard/src/views/site/SiteAnalyticsUptime.vue dashboard/src2/components/site/SiteUptime.vue`
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6879f67d68d8833095c670d458a45497