### PR TITLE
Add average uptime info in analytics

### DIFF
--- a/dashboard/src2/components/site/AnalyticsCard.vue
+++ b/dashboard/src2/components/site/AnalyticsCard.vue
@@ -1,7 +1,12 @@
 <template>
 	<div class="rounded-md border">
 		<div class="flex h-12 items-center justify-between border-b px-5">
-			<h3 class="text-lg font-medium text-gray-900">{{ title }}</h3>
+			<h3 class="text-lg font-medium text-gray-900">
+				{{ title }}
+				<span v-if="subtitle" class="ml-2 text-sm font-normal text-gray-600">
+					{{ subtitle }}
+				</span>
+			</h3>
 			<slot name="action"></slot>
 		</div>
 		<slot></slot>
@@ -11,6 +16,6 @@
 <script>
 export default {
 	name: 'AnalyticsCard',
-	props: ['title']
+	props: ['title', 'subtitle'],
 };
 </script>

--- a/dashboard/src2/components/site/SiteAnalytics.vue
+++ b/dashboard/src2/components/site/SiteAnalytics.vue
@@ -29,7 +29,7 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Uptime">
+			<AnalyticsCard title="Uptime" :subtitle="uptimeSubtitle">
 				<SiteUptime
 					:data="$resources.analytics?.data?.uptime"
 					:loading="$resources.analytics.loading"
@@ -461,6 +461,20 @@ export default {
 			return {
 				datasets: [requestCount.map((d) => [+new Date(d.date), d.value])],
 			};
+		},
+		uptimeSubtitle() {
+			const uptime = this.$resources.analytics.data?.uptime;
+			if (!uptime) return '';
+
+			let total = 0;
+			let i = 0;
+			for (; i < uptime.length; i++) {
+				if (typeof uptime[i].value !== 'number') break;
+				total += uptime[i].value;
+			}
+			const average = ((total / i) * 100).toFixed(2);
+
+			return !isNaN(average) ? `Average: ${average}%` : '';
 		},
 		requestCountByPathData() {
 			let requestCountByPath =

--- a/dashboard/src2/components/site/SiteUptime.vue
+++ b/dashboard/src2/components/site/SiteUptime.vue
@@ -8,21 +8,22 @@
 	<div v-else class="mx-4 mt-8" v-for="type in uptimeTypes" :key="type.key">
 		<div class="flex h-10 justify-between">
 			<div
-				v-for="d in data"
-				:key="d.date"
+				v-for="(d, i) in data"
+				:key="d.date || i"
 				class="w-1.5 rounded"
 				:class="[
+					isNewDay(i) ? 'border-l border-gray-300' : '',
 					d[type.key] === undefined
-							? 'bg-white'
-							: d[type.key] === 1
+						? 'bg-white'
+						: d[type.key] === 1
 							? 'bg-[#84cc16]'
-							: d[type.key] >= 0.90
-							? 'bg-[#a3e635]'
-							: d[type.key] === 0 || d[type.key] < 0.3
-							? 'bg-[#ef4444]'
-							: d[type.key] >= 0.3 && d[type.key] <= 0.6
-							? 'bg-[#f59e0b]'
-							: 'bg-[#fcd34d]',
+							: d[type.key] >= 0.9
+								? 'bg-[#a3e635]'
+								: d[type.key] === 0 || d[type.key] < 0.3
+									? 'bg-[#ef4444]'
+									: d[type.key] >= 0.3 && d[type.key] <= 0.6
+										? 'bg-[#f59e0b]'
+										: 'bg-[#fcd34d]',
 				]"
 				:title="
 					d[type.key]
@@ -58,12 +59,21 @@ export default {
 			const average = ((total / i) * 100).toFixed(2);
 
 			return !isNaN(average) ? `Average: ${average}%` : '';
-		}
+		},
 	},
 	methods: {
 		formatDate(date) {
 			return DateTime.fromSQL(date).toLocaleString(DateTime.DATETIME_FULL);
-		}
-	}
+		},
+		isNewDay(index) {
+			if (index === 0) return false;
+			const prev = this.data[index - 1]?.date;
+			const curr = this.data[index]?.date;
+			if (!prev || !curr) return false;
+			const prevDay = DateTime.fromSQL(prev);
+			const currDay = DateTime.fromSQL(curr);
+			return !prevDay.hasSame(currDay, 'day');
+		},
+	},
 };
 </script>


### PR DESCRIPTION
## Summary
- support subtitle in AnalyticsCard
- compute uptime average in SiteAnalytics and display it
- add day separators on uptime bars

## Testing
- `npx prettier -w dashboard/src2/components/site/AnalyticsCard.vue dashboard/src2/components/site/SiteAnalytics.vue dashboard/src2/components/site/SiteUptime.vue`
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_687f7f9bc7588330959a915496d4be44