### PR TITLE
Add PIP dependency to release groups

### DIFF
--- a/press/patches.txt
+++ b/press/patches.txt
@@ -98,6 +98,7 @@ press.press.doctype.telegram_group.patches.create_groups_from_press_settings
 press.press.doctype.app_release.patches.set_clone_directory
 press.press.doctype.database_server_mariadb_variable.patches.add_unique_constraint
 press.press.doctype.release_group.patches.sync_common_site_config
+press.press.doctype.release_group.patches.add_pip_dependency_in_release_group
 execute:frappe.delete_doc('Central Site Migration')
 execute:frappe.delete_doc('Central Server')
 execute:frappe.delete_doc('Feature Traction')

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -15,6 +15,7 @@ from subprocess import Popen
 from typing import Literal
 
 import frappe
+from frappe import _
 import semantic_version
 from frappe.core.utils import find
 from frappe.model.document import Document
@@ -453,7 +454,17 @@ class DeployCandidate(Document):
 		if dependency.islower():
 			dependency = dependency.upper() + "_VERSION"
 
-		version = find(self.dependencies, lambda x: x.dependency == dependency).version
+		dependency_doc = find(self.dependencies, lambda x: x.dependency == dependency)
+
+		if not dependency_doc or not dependency_doc.version:
+			frappe.throw(
+				_("Dependency {0} is not configured for Deploy Candidate {1}.").format(
+					dependency,
+					self.name,
+				)
+			)
+
+		version = dependency_doc.version
 
 		if as_env:
 			return f"{dependency} {version}"

--- a/press/press/doctype/release_group/patches/add_pip_dependency_in_release_group.py
+++ b/press/press/doctype/release_group/patches/add_pip_dependency_in_release_group.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+        for name in frappe.db.get_all("Release Group", pluck="name"):
+                if frappe.db.exists(
+                        "Release Group Dependency", {"parent": name, "dependency": "PIP_VERSION"}
+                ):
+                        continue
+
+                release_group = frappe.get_doc("Release Group", name)
+
+                pip_version = None
+                if release_group.version:
+                        pip_version = frappe.db.get_value(
+                                "Frappe Version Dependency",
+                                {"parent": release_group.version, "dependency": "PIP_VERSION"},
+                                "version",
+                        )
+
+                if not pip_version:
+                        pip_version = "25.3"
+
+                release_group.append(
+                        "dependencies",
+                        {"dependency": "PIP_VERSION", "version": pip_version},
+                )
+                release_group.db_update_all()

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -47,11 +47,12 @@ if TYPE_CHECKING:
 	from press.press.doctype.user_ssh_key.user_ssh_key import UserSSHKey
 
 DEFAULT_DEPENDENCIES = [
-	{"dependency": "NVM_VERSION", "version": "0.36.0"},
-	{"dependency": "NODE_VERSION", "version": "14.19.0"},
-	{"dependency": "PYTHON_VERSION", "version": "3.7"},
-	{"dependency": "WKHTMLTOPDF_VERSION", "version": "0.12.5"},
-	{"dependency": "BENCH_VERSION", "version": "5.25.1"},
+        {"dependency": "NVM_VERSION", "version": "0.36.0"},
+        {"dependency": "NODE_VERSION", "version": "14.19.0"},
+        {"dependency": "PYTHON_VERSION", "version": "3.7"},
+        {"dependency": "WKHTMLTOPDF_VERSION", "version": "0.12.5"},
+        {"dependency": "BENCH_VERSION", "version": "5.25.1"},
+        {"dependency": "PIP_VERSION", "version": "25.3"},
 ]
 
 SUPPORTED_WKHTMLTOPDF_VERSIONS = ["0.12.5", "0.12.6"]


### PR DESCRIPTION
## Summary
- add PIP_VERSION to the default release group dependencies so new groups expose the variable
- create a data patch that backfills the PIP dependency on existing release groups
- register the patch in the global patch list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6909d0e543a08330b22fcb0d0f7c5950